### PR TITLE
Fix admin page auth

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,8 @@ class ApplicationController < ActionController::Base
   protected
 
   def authenticate_admin_user!
+    authenticate_user!
+
     raise SecurityError unless current_user.has_role? :admin
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,22 +7,24 @@ class ApplicationController < ActionController::Base
 
   protected
 
-  def configure_permitted_parameters
-    added_attrs = [ :name, :organization, :profile, :comment, :birthday, :gender, :personality, :color_id, :shop_id, :profimg, tag_ids: [] ]
-    devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
-    devise_parameter_sanitizer.permit :account_update, keys: added_attrs
-  end
+    def configure_permitted_parameters
+      added_attrs = [ :name, :organization, :profile, :comment, :birthday, :gender, :personality, :color_id, :shop_id, :profimg, tag_ids: [] ]
+      devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
+      devise_parameter_sanitizer.permit :account_update, keys: added_attrs
+    end
 
-  # Security Error for Admin
-  rescue_from SecurityError do |exception|
-    redirect_to root_path, notice: '管理者画面へのアクセス権限がありません！'
-  end
+    # Authenticate Admin User
+    def authenticate_admin_user!
+      authenticate_user!
 
-  protected
+      unless current_user.has_role? :admin
+        raise SecurityError
+      end
+    end
 
-  def authenticate_admin_user!
-    authenticate_user!
-
-    raise SecurityError unless current_user.has_role? :admin
-  end
+    # Security Error for Admin
+    rescue_from SecurityError do |exception|
+      flash[:danger] = "管理者画面へのアクセス権限がありません！"
+      redirect_to root_path
+    end
 end


### PR DESCRIPTION
Closes #81 

- 管理者画面アクセス時にログイン済みか認証するように修正
  + 未ログイン時はログイン画面にリダイレクト