### PR TITLE
Sns auth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,11 @@ gem 'jquery-rails'
 # Devise
 gem 'devise'
 
+# SNS Auth
+gem 'omniauth-google-oauth2'
+gem 'omniauth-twitter'
+gem 'omniauth-facebook'
+
 # rolify
 gem 'rolify'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,8 @@ GEM
       activesupport (>= 3.0.0)
     erubi (1.9.0)
     execjs (2.7.0)
+    faraday (1.0.1)
+      multipart-post (>= 1.2, < 3)
     ffi (1.12.2)
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
@@ -115,6 +117,7 @@ GEM
     has_scope (0.7.2)
       actionpack (>= 4.1)
       activesupport (>= 4.1)
+    hashie (4.1.0)
     hirb (0.7.3)
     hirb-unicode (0.0.5)
       hirb (~> 0.5)
@@ -132,6 +135,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jwt (2.2.1)
     kaminari (1.2.0)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.0)
@@ -169,9 +173,37 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.0)
     msgpack (1.3.3)
+    multi_json (1.14.1)
+    multi_xml (0.6.0)
+    multipart-post (2.1.1)
     nio4r (2.5.2)
     nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
+    oauth (0.5.4)
+    oauth2 (1.4.4)
+      faraday (>= 0.8, < 2.0)
+      jwt (>= 1.0, < 3.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    omniauth (1.9.1)
+      hashie (>= 3.4.6)
+      rack (>= 1.6.2, < 3)
+    omniauth-facebook (6.0.0)
+      omniauth-oauth2 (~> 1.2)
+    omniauth-google-oauth2 (0.8.0)
+      jwt (>= 2.0)
+      omniauth (>= 1.1.1)
+      omniauth-oauth2 (>= 1.6)
+    omniauth-oauth (1.1.0)
+      oauth
+      omniauth (~> 1.0)
+    omniauth-oauth2 (1.6.0)
+      oauth2 (~> 1.1)
+      omniauth (~> 1.9)
+    omniauth-twitter (1.4.0)
+      omniauth-oauth (~> 1.1)
+      rack
     orm_adapter (0.5.0)
     pg (1.2.2)
     polyamorous (2.3.2)
@@ -348,6 +380,9 @@ DEPENDENCIES
   jquery-rails
   letter_opener_web
   listen (>= 3.0.5, < 3.2)
+  omniauth-facebook
+  omniauth-google-oauth2
+  omniauth-twitter
   pg (>= 0.18, < 2.0)
   pry-byebug
   pry-doc

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,36 @@
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+
+  # Google
+  def google_oauth2
+    callback_for(:google)
+  end
+
+  # Twitter
+  def twitter
+    callback_for(:twitter)
+  end
+
+  # Facebook
+  def facebook
+    callback_for(:facebook)
+  end
+
+  # Callback Base
+  def callback_for(provider)
+    @omniauth = request.env["omniauth.auth"]
+    info = User.find_oauth(@omniauth)
+    @user = info[:user]
+
+    if @user.persisted?
+      sign_in_and_redirect @user, event: :authentication
+      set_flash_message(:notice, :success, kind: "#{provider}".capitalize) if is_navigational_format?
+    else
+      @sns = info[:sns]
+      render template: "devise/registrations/new"
+    end
+  end
+
+  def failure
+    redirect_to root_path
+  end
+end

--- a/app/models/sns_credential.rb
+++ b/app/models/sns_credential.rb
@@ -1,0 +1,3 @@
+class SnsCredential < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,6 +80,9 @@ class User < ApplicationRecord
   # My Shop
   belongs_to :shop, optional: true
 
+  # SNS Credentials
+  has_many :sns_credentials, dependent: :destroy
+
   # Devise
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,7 +85,8 @@ class User < ApplicationRecord
 
   # Devise
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable, :confirmable
+         :recoverable, :rememberable, :validatable, :confirmable,
+         :omniauthable, omniauth_providers: %i[google_oauth2 twitter facebook]
 
   # Config for Updating Profile
   def update_without_current_password(params, *options)
@@ -99,6 +100,62 @@ class User < ApplicationRecord
     result = update_attributes(params, *options)
     clean_up_passwords
     result
+  end
+
+  # Find OAuth
+  def self.find_oauth(auth)
+    snscredential = SnsCredential.where(uid: auth.uid, provider: auth.provider).first
+
+    if snscredential.present?
+      info = {
+        user: with_sns_data(auth, snscredential),
+        sns: snscredential,
+      }
+    else
+      info = without_sns_data(auth)
+    end
+
+    return info
+  end
+
+  # Create with SNS Data
+  def self.with_sns_data(auth, snscredential)
+    user = User.find(snscredential.user_id).first
+
+    unless user.present?
+      user = User.new(
+        name: auth.info.name,
+        email: auth.info.email,
+        password: Devise.friendly_token[0,20],
+      )
+    end
+
+    return user
+  end
+
+  # Create without SNS Data
+  def self.without_sns_data(auth)
+    user = User.where(email: auth.info.email).first
+
+    if user.present?
+      sns = SnsCredential.create(
+        uid: auth.uid,
+        provider: auth.provider,
+        user_id: user.id
+      )
+    else
+      user = User.new(
+        name: auth.info.name,
+        email: auth.info.email,
+        password: Devise.friendly_token[0,20],
+      )
+      sns = SnsCredential.new(
+        uid: auth.uid,
+        provider: auth.provider
+      )
+    end
+
+    return { user: user, sns: sns }
   end
 
   # Review

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -261,6 +261,21 @@ Devise.setup do |config|
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
 
+  config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'],
+                                  ENV['GOOGLE_CLIENT_SECRET'],
+                                  redirect_uri: "#{ENV['HOST']}/auth/google_oauth2/callback",
+                                  skip_jwt: true
+
+  config.omniauth :twitter, ENV['TWITTER_CLIENT_ID'],
+                            ENV['TWITTER_CLIENT_SECRET'],
+                            oauth_callback: "#{ENV['HOST']}/auth/twitter/callback"
+
+  config.omniauth :facebook, ENV['FACEBOOK_CLIENT_ID'],
+                             ENV['FACEBOOK_CLIENT_SECRET'],
+                             callback_url: "#{ENV['HOST']}/auth/facebook/callback"
+
+  OmniAuth.config.logger = Rails.logger if Rails.env.development?
+
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
     controllers: {
       registrations: 'users/registrations',
       confirmations: 'users/confirmations',
+      omniauth_callbacks: 'users/omniauth_callbacks',
     }
 
   # Profile Image

--- a/db/migrate/20200505110236_create_sns_credentials.rb
+++ b/db/migrate/20200505110236_create_sns_credentials.rb
@@ -1,0 +1,11 @@
+class CreateSnsCredentials < ActiveRecord::Migration[5.2]
+  def change
+    create_table :sns_credentials do |t|
+      t.string :provider
+      t.string :uid
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_02_171939) do
+ActiveRecord::Schema.define(version: 2020_05_05_110236) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,6 +71,15 @@ ActiveRecord::Schema.define(version: 2020_05_02_171939) do
     t.index ["name"], name: "index_shops_on_name"
   end
 
+  create_table "sns_credentials", force: :cascade do |t|
+    t.string "provider"
+    t.string "uid"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_sns_credentials_on_user_id"
+  end
+
   create_table "tags", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -113,4 +122,5 @@ ActiveRecord::Schema.define(version: 2020_05_02_171939) do
     t.index ["user_id"], name: "index_users_roles_on_user_id"
   end
 
+  add_foreign_key "sns_credentials", "users"
 end

--- a/spec/models/sns_credential_spec.rb
+++ b/spec/models/sns_credential_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SnsCredential, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Closes #78 

+ gem`omniauthable`を追加
  - `bundle install`の必要アリ
+ `SnsCredentials`モデルを作成
  - `migrate`の必要アリ
+ 以下のSNSを用いたアカウント認証機能を追加
  - Google
  - Twitter
  - Facebook (開発時は開発用アカウントのみ認証可能)