### PR TITLE
広告モデルの基本機能を実装

### DIFF
--- a/.pryrc
+++ b/.pryrc
@@ -20,7 +20,7 @@ if defined? Hirb
   end
 
   module Hirb
-    IGNORE = [:created_at, :updated_at, :profimg, :reset_password_token, :reset_password_sent_at, :remember_created_at, :encrypted_password]
+    IGNORE = [:created_at, :updated_at, :profimg, :adimg, :reset_password_token, :reset_password_sent_at, :remember_created_at, :encrypted_password]
   end
 
   module Hirb::Views::Rails #:nodoc:

--- a/app/admin/advertisements.rb
+++ b/app/admin/advertisements.rb
@@ -1,0 +1,78 @@
+ActiveAdmin.register Advertisement do
+  # Permit
+  permit_params :sponsor, :adimg, :url, :start_date, :end_date, ad_contract_attributes: [:shop_id, :_destroy, :id]
+
+  # Controller
+  controller do
+    def create
+      if permitted_params[:advertisement][:adimg]
+        params[:advertisement][:adimg] = permitted_params[:advertisement][:adimg].read
+      end
+
+      super
+    end
+
+    def update
+      if permitted_params[:advertisement][:adimg]
+        params[:advertisement][:adimg] = permitted_params[:advertisement][:adimg].read
+      end
+
+      super
+    end
+  end
+
+  # Index
+  index do
+    selectable_column
+    column :id
+    column :sponsor
+    column :url
+    column :placed_shop
+    column :start_date
+    column :end_date
+    column :created_at
+    column :updated_at
+    actions
+  end
+
+  # Show
+  show do |ad|
+    attributes_table do
+      row :id
+      row :sponsor
+      row :url
+      row :start_date
+      row :end_date
+      row :created_at
+      row :updated_at
+    end
+
+    panel "Advertisement Image" do
+      image_tag adimg_path(ad.id)
+    end
+
+    panel "Shops" do
+      table_for ad.placed_shop do
+        column :name do |shop|
+          link_to shop.name, admin_shop_path(shop)
+        end
+      end
+    end
+  end
+
+  # Form
+  form do |f|
+    f.inputs do
+      f.input :sponsor
+      f.input :url
+      f.has_many :ad_contract, allow_destroy: true, new_record: true, heading: "掲載先" do |t|
+        t.input :shop
+      end
+      f.input :start_date
+      f.input :end_date
+      f.file_field :adimg, accept: "image/jpg, image/jpeg, image/png, image/gif"
+    end
+    f.actions
+  end
+
+end

--- a/app/admin/shops.rb
+++ b/app/admin/shops.rb
@@ -37,5 +37,13 @@ ActiveAdmin.register Shop do
         end
       end
     end
+
+    panel "Advertisements" do
+      table_for shop.advertisement do
+        column :name do |ad|
+          link_to ad.sponsor, admin_advertisement_path(ad)
+        end
+      end
+    end
   end
 end

--- a/app/controllers/advertisements_controller.rb
+++ b/app/controllers/advertisements_controller.rb
@@ -1,0 +1,7 @@
+class AdvertisementsController < ApplicationController
+  # Advertisement Image
+  def show_adimg
+    @ad = Advertisement.find(params[:ad_id])
+    send_data(@ad.adimg)
+  end
+end

--- a/app/models/ad_contract.rb
+++ b/app/models/ad_contract.rb
@@ -1,0 +1,5 @@
+class AdContract < ApplicationRecord
+  # Advertisement <-> Shop
+  belongs_to :advertisement
+  belongs_to :shop
+end

--- a/app/models/advertisement.rb
+++ b/app/models/advertisement.rb
@@ -1,0 +1,5 @@
+class Advertisement < ApplicationRecord
+  # AdContract -> Shop
+  has_many :ad_contract, dependent: :delete_all
+  has_many :placed_shop, through: :ad_contract, source: :shop
+end

--- a/app/models/advertisement.rb
+++ b/app/models/advertisement.rb
@@ -2,4 +2,7 @@ class Advertisement < ApplicationRecord
   # AdContract -> Shop
   has_many :ad_contract, dependent: :delete_all
   has_many :placed_shop, through: :ad_contract, source: :shop
+
+  # Nest Create
+  accepts_nested_attributes_for :ad_contract, :allow_destroy => true
 end

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -3,6 +3,10 @@ class Shop < ApplicationRecord
   has_many :checkin_record, dependent: :delete_all
   has_many :checkined_user, through: :checkin_record, source: :user
 
+  # AdContract -> Advertisement
+  has_many :ad_contract, dependent: :delete_all
+  has_many :advertisement, through: :ad_contract
+
   # My User
   has_many :user
 

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -159,6 +159,9 @@ ActiveAdmin.setup do |config|
   #
   config.filter_attributes = [:encrypted_password, :password, :password_confirmation]
 
+  # == Display Name
+  config.display_name_methods = [ :display_name, :full_name, :name, :user_name, :login, :title, :email, :sponsor, :to_s]
+
   # == Localize Date/Time Format
   #
   # Set the localize format to display dates and times.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -35,6 +35,7 @@ ja:
       tag: タグ
       contact: お問い合わせ
       category: カテゴリ
+      advertisement: 広告
     attributes:
       user:
         id: ID

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,9 @@ Rails.application.routes.draw do
     end
   end
 
+  # Advertisement Image
+  get 'ads/:ad_id/image', to: 'advertisements#show_adimg', as: 'adimg'
+
   # Admin
   ActiveAdmin.routes(self)
 

--- a/db/migrate/20200507233146_create_advertisements.rb
+++ b/db/migrate/20200507233146_create_advertisements.rb
@@ -1,0 +1,13 @@
+class CreateAdvertisements < ActiveRecord::Migration[5.2]
+  def change
+    create_table :advertisements do |t|
+      t.string :sponsor, null: false
+      t.binary :adimg, null: false
+      t.string :url
+      t.date :start_date, null: false
+      t.date :end_date, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200507233208_create_ad_contracts.rb
+++ b/db/migrate/20200507233208_create_ad_contracts.rb
@@ -1,0 +1,10 @@
+class CreateAdContracts < ActiveRecord::Migration[5.2]
+  def change
+    create_table :ad_contracts do |t|
+      t.bigint :advertisement_id, null: false
+      t.bigint :shop_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,27 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_07_182649) do
+ActiveRecord::Schema.define(version: 2020_05_07_233208) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "ad_contracts", force: :cascade do |t|
+    t.bigint "advertisement_id", null: false
+    t.bigint "shop_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "advertisements", force: :cascade do |t|
+    t.string "sponsor", null: false
+    t.binary "adimg", null: false
+    t.string "url"
+    t.date "start_date", null: false
+    t.date "end_date", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "categories", force: :cascade do |t|
     t.string "name", null: false

--- a/spec/models/ad_contract_spec.rb
+++ b/spec/models/ad_contract_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe AdContract, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/advertisement_spec.rb
+++ b/spec/models/advertisement_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Advertisement, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## Issue

#99 

## 実装内容

- 広告モデル及びコントローラーの作成
- 店舗モデルとの関連付け

## 必要手順

- `db:migrate`

## 確認方法

- 管理者ページで作成/表示

## 未実装

- K-Displayへの表示