### PR TITLE
Support real-time update with advertisement

### DIFF
--- a/app/assets/javascripts/channels/display.coffee
+++ b/app/assets/javascripts/channels/display.coffee
@@ -8,9 +8,11 @@ App.display = App.cable.subscriptions.create "DisplayChannel",
 
   received: (data) ->
     if data.code == 'checkin'
-      addProf(data.user, data.tags)
+      addUser(data.user)
+      setChangeFlag()
 
     if data.code == 'checkout'
-      removeProf(data.user)
+      removeUser(data.user)
+      setChangeFlag()
 
     return

--- a/app/assets/javascripts/displays.js
+++ b/app/assets/javascripts/displays.js
@@ -1,4 +1,185 @@
-let swiper = new Swiper('.swiper-container', {
+let initSwiperSlides = () => {
+  $(".swiper-slide").not(".swiper-slide-duplicate").each((index, slide) => {
+    if ($(slide).hasClass("prof_user")) {
+      userSlides.push({
+        type: "user",
+        body: {
+          id: slide.id.replace("prof_user_", ""),
+          name: $(slide).find(".prof_name").text(),
+          organization: $(slide).find(".prof_org").text(),
+          comment: $(slide).find(".prof_msg p").text(),
+          color: $(slide).find(".displayprof").attr("class").replace("displayprof bg_", ""),
+          tags: $(slide).find(".prof_tag").text().replace(/\r?\n|&nbsp;| /g, "").split("#").slice(1),
+        }
+      })
+    } else if ($(slide).hasClass("prof_ad")) {
+      adSlides.push({
+        type: "ad",
+        body: {
+          id: slide.id.replace("prof_ad_", ""),
+          sponsor: $(slide).find(".sponsor").text(),
+          url: $(slide).find(".qrcode").attr("src")
+        }
+      })
+    }
+  })
+}
+
+let setChangeFlag = () => {
+  changeFlag = true
+}
+
+let addUser = (user) => {
+  userSlides.push(user)
+}
+
+let removeUser = (user) => {
+  let target
+  userSlides.forEach((slide, index) => {
+    if (slide.body.id == user.id)
+      target = index
+  })
+  userSlides.splice(target, 1)
+}
+
+let updateSlide = () => {
+  if (userSlides.length || adSlides.length) {
+    if (userSlides.length >= adSlides.length)
+      swiperSlides = getOrderedSlides(userSlides, adSlides)
+    else
+      swiperSlides = getOrderedSlides(adSlides, userSlides)
+  } else {
+    swiperSlides = userSlides.concat(adSlides)
+  }
+
+  swiper.removeAllSlides()
+  swiperSlides.forEach((slide) => {
+    if (slide.type == "user")
+      addUserSlide(slide.body)
+    else
+      addAdSlide(slide.body)
+  })
+  swiper.update(true)
+}
+
+let getOrderedSlides = (bases, items) => {
+  let slides = bases.slice()
+  let step = Math.floor(bases.length / items.length)
+
+  items.forEach((item, index) => {
+    slides.splice(step * (index + 1) + index, 0, item)
+  })
+  return slides
+}
+
+let addUserSlide = (user) => {
+  let slide = $(document.createElement("div"))
+  $(slide).attr("id", "prof_user_" + user.id)
+  $(slide).addClass("swiper-slide prof_user")
+
+  let section = $(document.createElement("section"))
+  $(section).addClass("displayprof bg_" + user.color)
+  $(slide).append(section)
+
+  let wrap = $(document.createElement("div"))
+  $(wrap).addClass("wrap")
+  $(section).append(wrap)
+
+  let post_profimg = $(document.createElement("div"))
+  $(post_profimg).addClass("post_profimg")
+  $(wrap).append(post_profimg)
+
+  let mainimgframe = $(document.createElement("div"))
+  $(mainimgframe).addClass("mainimgframe")
+  $(post_profimg).append(mainimgframe)
+
+  let pic = $(document.createElement("img"))
+  $(pic).attr("src", "/users/" + user.id + "/show_profimg")
+  $(mainimgframe).append(pic)
+
+  let prof_body = $(document.createElement("div"))
+  $(prof_body).addClass("prof_body")
+  $(wrap).append(prof_body)
+
+  let under = $(document.createElement("div"))
+  $(under).addClass("under")
+  $(prof_body).append(under)
+
+  let prof_name = $(document.createElement("h1"))
+  $(prof_name).html(user.name)
+  $(prof_name).addClass("prof_name")
+  $(under).append(prof_name)
+
+  let prof_org = $(document.createElement("h2"))
+  $(prof_org).html(user.organization)
+  $(prof_org).addClass("prof_org")
+  $(prof_body).append(prof_org)
+
+  let prof_tag = $(document.createElement("h2"))
+  let temp = ""
+  for (tag of user.tags) {
+    temp += "#" + tag + " "
+  }
+  $(prof_tag).html(temp)
+  $(prof_tag).addClass("prof_tag")
+  $(prof_body).append(prof_tag)
+
+  let clearfix = $(document.createElement("div"))
+  $(clearfix).addClass("clearfix")
+  $(wrap).append(clearfix)
+
+  let prof_msg = $(document.createElement("div"))
+  $(prof_msg).addClass("prof_msg")
+  $(wrap).append(prof_msg)
+
+  let prof_msg_p = $(document.createElement("p"))
+  let msg = user.comment ? "&quot;" + user.comment + "&quot;" : ""
+  $(prof_msg_p).html(msg)
+  $(prof_msg).append(prof_msg_p)
+
+  swiper.appendSlide(slide)
+}
+
+let addAdSlide = (ad) => {
+  let slide = $(document.createElement("div"))
+  $(slide).attr("id", "prof_ad_" + ad.id)
+  $(slide).addClass("swiper-slide prof_ad")
+
+  let section = $(document.createElement("section"))
+  $(section).addClass("displayprof bg_black")
+  $(section).css("background-image", "url(/ads/" + ad.id + "/image")
+  $(slide).append(section)
+
+  let wrap = $(document.createElement("div"))
+  $(wrap).addClass("wrap")
+  $(section).append(wrap)
+
+  let sponsor = $(document.createElement("h1"))
+  $(sponsor).html(ad.sponsor)
+  $(sponsor).addClass("sponsor")
+  $(wrap).append(sponsor)
+
+  if (ad.url) {
+    let adimg = $(document.createElement("img"))
+    $(adimg).attr("src", ad.url)
+    $(adimg).addClass("qrcode")
+    $(wrap).append(adimg)
+  }
+
+  swiper.appendSlide(slide)
+}
+
+
+// ==================================================
+//   Main
+// ==================================================
+
+let changeFlag = false
+let userSlides = []
+let adSlides = []
+let swiperSlides = []
+
+let swiper = new Swiper(".swiper-container", {
   loop: true,
   autoplay: {
     delay: 2000,
@@ -7,73 +188,14 @@ let swiper = new Swiper('.swiper-container', {
   speed: 800,
   slidesPerView: 1,
   spaceBetween: 0,
+  on: {
+    fromEdge: () => {
+      if (changeFlag) {
+        changeFlag = false
+        updateSlide()
+      }
+    },
+  },
 })
 
-let addProf = (user) => {
-  let slide = $(document.createElement('div'))
-  $(slide).attr('class', 'prof_' + user.id + ' swiper-slide')
-
-  let section = $(document.createElement('section'))
-  $(section).attr('class', 'displayprof bg_' + user.color)
-  $(slide).append(section)
-
-  let wrap = $(document.createElement('div'))
-  $(wrap).attr('class', 'wrap')
-  $(section).append(wrap)
-
-  let post_profimg = $(document.createElement('div'))
-  $(post_profimg).attr('class', 'post_profimg')
-  $(wrap).append(post_profimg)
-
-  let mainimgframe = $(document.createElement('div'))
-  $(mainimgframe).attr('class', 'mainimgframe')
-  $(post_profimg).append(mainimgframe)
-
-  let pic = $(document.createElement('img'))
-  $(pic).attr('src', '/users/' + user.id + '/show_profimg')
-  $(mainimgframe).append(pic)
-
-  let prof_body = $(document.createElement('div'))
-  $(prof_body).attr('class', 'prof_body')
-  $(wrap).append(prof_body)
-
-  let under = $(document.createElement('div'))
-  $(under).attr('class', 'under')
-  $(prof_body).append(under)
-
-  let prof_name = $(document.createElement('h1'))
-  prof_name.html(user.name)
-  $(under).append(prof_name)
-
-  let prof_org = $(document.createElement('h2'))
-  prof_org.html(user.organization)
-  $(prof_body).append(prof_org)
-
-  let prof_tag = $(document.createElement('h2'))
-  let temp = ''
-  for (tag of user.tags) {
-    temp += '#' + tag.name + ' '
-  }
-  prof_tag.html(temp)
-  $(prof_body).append(prof_tag)
-
-  let clearfix = $(document.createElement('div'))
-  $(clearfix).attr('class', 'clearfix')
-  $(wrap).append(clearfix)
-
-  let prof_msg = $(document.createElement('div'))
-  $(prof_msg).attr('class', 'prof_msg')
-  $(wrap).append(prof_msg)
-
-  let prof_msg_p = $(document.createElement('p'))
-  let msg = user.comment ? '&quot;' + user.comment + '&quot;' : ''
-  prof_msg_p.html(msg)
-  $(prof_msg).append(prof_msg_p)
-
-  swiper.appendSlide(slide)
-}
-
-let removeProf = (user) => {
-  let index = $('.prof_' + user.id).attr('data-swiper-slide-index')
-  swiper.removeSlide(index)
-}
+initSwiperSlides()

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -40,12 +40,15 @@ class UsersController < ApplicationController
         DisplayChannel.broadcast_to('master',
           code: 'checkin',
           user: {
-            id: @user.id,
-            name: @user.name,
-            organization: @user.organization,
-            comment: @user.comment,
-            color: @user.color.name,
-            tags: @user.tag,
+            type: "user",
+            body: {
+              id: @user.id,
+              name: @user.name,
+              organization: @user.organization,
+              comment: @user.comment,
+              color: @user.color.name,
+              tags: @user.tag.map{ |tag| tag.name },
+            },
           },
         )
         if @user.shop.id == current_user.shop.id
@@ -137,9 +140,9 @@ class UsersController < ApplicationController
       panels = []
       if users.present? and ads.present?
         if users.size >= ads.size
-          panels = set_panel_order(users, ads)
+          panels = get_ordered_slides(users, ads)
         else
-          panels = set_panel_order(ads, users)
+          panels = get_ordered_slides(ads, users)
         end
       else
         panels = users + ads
@@ -148,8 +151,8 @@ class UsersController < ApplicationController
       return panels
     end
 
-    # Set Item Alternate
-    def set_panel_order(bases, items)
+    # Get Ordered Slide
+    def get_ordered_slides(bases, items)
       step = bases.size / items.size
 
       items.each.with_index do |item, index|

--- a/app/views/layouts/_display_user.html.erb
+++ b/app/views/layouts/_display_user.html.erb
@@ -10,11 +10,11 @@
 
     <div class="prof_body">
       <div class="under">
-        <h1><%= user.name %></h1>
+        <h1 class="prof_name"><%= user.name %></h1>
       </div>
-      <h2><%= user.organization %></h2>
+      <h2 class="prof_org"><%= user.organization %></h2>
       <div class="multiline-text-container">
-        <h2 class="multiline-text">
+        <h2 class="prof_tag multiline-text">
           <% user.tag.each do |tag| %>
             #<%= tag.name %>&nbsp;
           <% end %>


### PR DESCRIPTION
## Issue

#99 

## 実装内容

- チェックイン/アウトユーザのリアルタイム更新に広告表示を対応
  + 更新時、スライドが1週するタイミングで仕様通りの表示順にして再構築

## 確認方法

- `/display` ページを開きながらゲストユーザのチェックイン/アウトを行う

## 未実装

- 広告表示のデザイン