### PR TITLE
Fix flash message when checkin fails

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -57,7 +57,7 @@ class UsersController < ApplicationController
         flash[:danger] = "マイショップが指定されていません"
       end
     else
-      flash[:danger] = "#{@user.name}は既に「#{current_user.shop.name}」にチェックイン済みです"
+      flash[:danger] = "#{@user.name}は既に「#{@user.get_checkin_shop.name}」にチェックイン済みです"
     end
 
     redirect_to root_path


### PR DESCRIPTION
## Issue

closes #150 

## 実装内容

- チェックイン失敗時におけるフラッシュメッセージの店舗名を修正

## 確認方法

- スタッフアカウントで既に多店舗にチェックイン済みのユーザをチェックインさせる