### PR TITLE
Update to be able to signup without mail auth

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -2,6 +2,7 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
   protected
 
     def after_confirmation_path_for(resource_name, resource)
+      sign_in(:user, resource)
       root_path
     end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -25,8 +25,10 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       sign_in_and_redirect @user, event: :authentication
       set_flash_message(:notice, :success, kind: "#{provider}".capitalize) if is_navigational_format?
     else
-      @sns = info[:sns]
-      render template: "devise/registrations/new"
+      @user.skip_confirmation!
+      @user.save
+      sign_in(:user, @user)
+      redirect_to edit_user_registration_path(@user.id)
     end
   end
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -33,7 +33,9 @@
       <% end %>
 
       <% if not @user.has_role? "admin" %>
-        <p class="p_item"><b>マイショップ </b><%= @user.shop.name || "none" %></p>
+        <% if @user.shop.present? %>
+          <p class="p_item"><b>マイショップ </b><%= @user.shop.name || "none" %></p>
+        <% end %>
 
         <% if not @user.has_role? "staff" %>
           <p class="p_item"><b>所属 </b>
@@ -45,7 +47,7 @@
           </p>
 
           <% if user_signed_in? and @user.id == current_user.id %>
-            <p class="p_item"><b>性別 </b><%= I18n.t("enums.user.gender.#{@user.gender}") %></p>
+            <p class="p_item"><b>性別 </b><%= t("enums.user.gender.#{@user.gender || 'default'}", default: "未登録") %></p>
             <p class="p_item"><b>生年月日 </b>
               <% if !@user.birthday.nil? %>
                 <%= @user.birthday %>


### PR DESCRIPTION
## Issue

closes #145 

## 実装内容

- SNSでサインアップ後、メール認証なしにアカウント作成されるよう変更
  + パスワードはランダム文字列で与える
  + サインアップ後プロフィール編集画面に遷移 (パスワードの更新も可能)

## 確認方法

- SNSを用いてサインアップ