### PR TITLE
Ad form

### DIFF
--- a/app/controllers/advertisements_controller.rb
+++ b/app/controllers/advertisements_controller.rb
@@ -1,7 +1,30 @@
 class AdvertisementsController < ApplicationController
+  # New
+  def new
+    @ad = Advertisement.new
+  end
+
+  # Create
+  def create
+    @ad = Advertisement.new(advertisement_params)
+
+    if @ad.save
+      flash[:success] = "広告の登録を受け付けました"
+      redirect_to root_path
+    else
+      render :new
+    end
+  end
+
   # Advertisement Image
   def show_adimg
     @ad = Advertisement.find(params[:ad_id])
     send_data(@ad.adimg)
   end
+
+  private
+
+    def advertisement_params
+      params.require(:advertisement).permit(:sponsor, :email, :adimg, :url, :start_date, :end_date, { placed_shop_ids: [] })
+    end
 end

--- a/app/models/advertisement.rb
+++ b/app/models/advertisement.rb
@@ -1,8 +1,36 @@
 class Advertisement < ApplicationRecord
+  # Validation
+  validates :sponsor, presence: true, length: { maximum: 16 }
+  validates :email, presence: true
+  validates :adimg, presence: true
+  validates :start_date, presence: true
+  validates :end_date, presence: true
+  validates :placed_shop, presence: true
+  validate :start_date_check
+  validate :end_date_check
+
   # AdContract -> Shop
   has_many :ad_contract, dependent: :delete_all
   has_many :placed_shop, through: :ad_contract, source: :shop
 
   # Nest Create
-  accepts_nested_attributes_for :ad_contract, :allow_destroy => true
+  accepts_nested_attributes_for :ad_contract, allow_destroy: true
+
+  private
+
+    def start_date_check
+      if self.start_date.present?
+        if self.start_date < Date.today
+          errors.add(:start_date, "に今日以降の日付を入力して下さい")
+        end
+      end
+    end
+
+    def end_date_check
+      if self.start_date.present? and self.end_date.present?
+        if self.start_date > self.end_date
+          errors.add(:end_date, "に開始日以降の日付を入力して下さい")
+        end
+      end
+    end
 end

--- a/app/views/advertisements/new.html.erb
+++ b/app/views/advertisements/new.html.erb
@@ -1,0 +1,52 @@
+<section>
+  <div class="wrap">
+    <h2>広告登録フォーム</h2>
+
+    <%= form_with model: @ad, url: advertisement_path, local: true do |f| %>
+      <%= render "devise/shared/error_messages", resource: @ad %>
+
+      <div class="field">
+        <%= f.label :sponsor %><i>(16文字以内)</i><br />
+        <%= f.text_field :sponsor, autocomplete: "name", autofocus: true %>
+      </div>
+
+      <div class="field">
+        <%= f.label :email %><br />
+        <%= f.email_field :email, autocomplete: "email" %>
+      </div>
+
+      <div class="field">
+        <%= f.label :url %><br />
+        <%= f.text_field :url, autocomplete: "url" %>
+      </div>
+
+      <div class="field">
+        <p>掲載する店舗を選択してください(複数選択可)</p>
+        <%= f.collection_check_boxes :placed_shop_ids, Shop.all, :id, :name do |s| %>
+          <%= s.check_box + s.label{s.text} %>
+        <% end %>
+      </div>
+
+      <div class="field">
+        <%= f.label :start_date %><br />
+        <%= f.date_select :start_date, prompt: "--", use_month_numbers: true, start_year: Time.now.year, end_year: Time.now.year + 2 %>
+      </div>
+
+      <div class="field">
+        <%= f.label :end_date %><br />
+        <%= f.date_select :end_date, prompt: "--", use_month_numbers: true, start_year: Time.now.year, end_year: Time.now.year + 2 %>
+      </div>
+
+      <div class="field">
+        <%= f.label :adimg, class:"button_area_blue" %><br />
+        <%= f.file_field :adimg, accept: "image/jpg, image/jpeg, image/png, image/gif" %>
+      </div>
+
+      <div class="center_buttons">
+        <div class="actions">
+          <%= f.submit "送信", class:"button_area" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</section>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -5,6 +5,7 @@
       <p class="p_item footer_link"><small><%= link_to "利用規約", tos_path, target:"_blank" %></small></p>
       <p class="p_item footer_link"><small><%= link_to "プライバシーポリシー", privacy_path, target:"_blank" %></small></p>
       <p class="p_item footer_link"><small><%= link_to "お問い合わせ", contact_path %></small></p>
+      <p class="p_item footer_link"><small><%= link_to "広告の登録", new_advertisement_path %></small></p>
       <% if user_signed_in? %>
         <p class="p_item footer_link"><small><%= link_to "退会", destroy_confirmation_path %></small></p>
       <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -59,6 +59,14 @@ ja:
         name: 名前
         email: メールアドレス
         message: お問い合わせ内容
+      advertisement:
+        sponsor: 名前
+        email: メールアドレス
+        adimg: 掲載画像
+        url: URL
+        start_date: 掲載開始日
+        end_date: 掲載終了日
+        placed_shop: 掲載先店舗
       admin:
         id: ID
   errors:
@@ -79,6 +87,17 @@ ja:
       message:
         blank: が空欄です
         too_long: が長すぎます
+      sponsor:
+        blank: が空欄です
+        too_long: が長すぎます
+      adimg:
+        blank: が空欄です
+      start_date:
+        blank: が空欄です
+      end_date:
+        blank: が空欄です
+      placed_shop:
+        blank: が空欄です
   enums:
     user:
       gender:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
   end
 
   # Advertisement Image
+  resource :advertisement, only: [:new, :create]
   get 'ads/:ad_id/image', to: 'advertisements#show_adimg', as: 'adimg'
 
   # Admin


### PR DESCRIPTION
## Issue

closes #132 

## 実装内容

- 広告登録フォームを実装

### 登録フォーム画面

![20-05-10_00-36-17_00](https://user-images.githubusercontent.com/6837211/81478142-550d5000-9256-11ea-9283-2bcea9f9b61f.png)


## 確認方法

- フッターに追加したリンクから登録フォームへ
- フォームのバリデーションの確認
- 管理者ページで登録されていることの確認