### PR TITLE
Remove password note in profile edit page

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -20,8 +20,7 @@
       <% end %>
 
       <div class="field">
-        <%= f.label :password %><em>(<%= @minimum_password_length %>文字以上)</em><br />
-        <i>*パスワードを変更しない場合は空欄のままにしてください</i><br />
+        <%= f.label :password %>変更<em>(<%= @minimum_password_length %>文字以上)</em><br />
         <%= f.password_field :password, autocomplete: "new-password" %>
         <% if @minimum_password_length %>
         <% end %>
@@ -29,7 +28,6 @@
 
       <div class="field">
         <%= f.label :password_confirmation %><br />
-        <i>*パスワードを変更しない場合は空欄のままにしてください</i><br />
         <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
       </div>
 


### PR DESCRIPTION
## Issue

closes #157 

## 実装内容

- プロフィール編集画面のパスワードの注意書きを削除
  +  ラベルの表記を「パスワード変更」に変更

![20-05-10_03-15-16_00](https://user-images.githubusercontent.com/6837211/81481662-9d376d00-926c-11ea-89d1-d0c14c03bf27.png)

## 確認方法

- プロフィール編集画面で確認