### PR TITLE
Fix regist ad image

### DIFF
--- a/app/controllers/advertisements_controller.rb
+++ b/app/controllers/advertisements_controller.rb
@@ -10,6 +10,10 @@ class AdvertisementsController < ApplicationController
 
   # Create
   def create
+    if params[:advertisement][:adimg]
+      params[:advertisement][:adimg] = params[:advertisement][:adimg].read
+    end
+
     @ad = Advertisement.new(advertisement_params)
 
     if @ad.save


### PR DESCRIPTION
## Issue

closes #162 

## 実装内容

- 広告登録時に画像が保存されないバグを修正

## 確認方法

- フォームから登録