### PR TITLE
adform img preview

### DIFF
--- a/app/assets/javascripts/form_img_preview.js
+++ b/app/assets/javascripts/form_img_preview.js
@@ -1,0 +1,30 @@
+$(function(){
+  //画像ファイルプレビュー表示のイベント追加 fileを選択時に発火するイベントを登録
+  $('.ad_form').on('change', 'input[type="file"]', function(e) {
+    var file = e.target.files[0],
+        reader = new FileReader(),
+        $preview = $(".ad_form_preview");
+        t = this;
+
+    // 画像ファイル以外の場合は何もしない
+    if(file.type.indexOf("image") < 0){
+      return false;
+    }
+
+    // ファイル読み込みが完了した際のイベント登録
+    reader.onload = (function(file) {
+      return function(e) {
+        //既存のプレビューを削除
+        $preview.empty();
+        // .prevewの領域の中にロードした画像を表示するimageタグを追加
+        $preview.append($('<img>').attr({
+                  src: e.target.result,
+                  class: "preview",
+                  title: file.name
+              }));
+      };
+    })(file);
+
+    reader.readAsDataURL(file);
+  });
+});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -739,3 +739,14 @@ img.libig_img {
   display: inline-block;
   /*width: 120px;*/
 }
+
+.ad_form_preview {
+  margin-top: 16px;
+  max-width: 460px;
+}
+
+.ad_form_preview img {
+  border-radius: 8px;
+  box-sizing: border-box;
+  border: 1px solid #1fdaff;
+}

--- a/app/views/advertisements/new.html.erb
+++ b/app/views/advertisements/new.html.erb
@@ -2,7 +2,7 @@
   <div class="wrap">
     <h2>広告登録フォーム</h2>
 
-    <%= form_with model: @ad, url: advertisement_path, local: true do |f| %>
+    <%= form_with model: @ad, url: advertisement_path, local: true, class:"ad_form" do |f| %>
       <%= render "devise/shared/error_messages", resource: @ad %>
 
       <div class="field">
@@ -16,12 +16,12 @@
       </div>
 
       <div class="field">
-        <%= f.label :url %><br />
+        <%= f.label :url %><i>(任意)</i><br />
         <%= f.text_field :url, autocomplete: "url" %>
       </div>
 
       <div class="field">
-        <p>掲載する店舗を選択してください(複数選択可)</p>
+        <p>掲載する店舗を選択してください<i>(複数選択可)</i></p>
         <%= f.collection_check_boxes :placed_shop_ids, Shop.all, :id, :name do |s| %>
           <%= s.check_box + s.label{s.text} %>
         <% end %>
@@ -29,17 +29,18 @@
 
       <div class="field">
         <%= f.label :start_date %><br />
-        <%= f.date_select :start_date, prompt: "--", use_month_numbers: true, start_year: Time.now.year, end_year: Time.now.year + 2 %>
+        <%= f.date_select :start_date, prompt: "--", use_month_numbers: true, selected:Time.now, start_year: Time.now.year, end_year: Time.now.year + 2 %>
       </div>
 
       <div class="field">
         <%= f.label :end_date %><br />
-        <%= f.date_select :end_date, prompt: "--", use_month_numbers: true, start_year: Time.now.year, end_year: Time.now.year + 2 %>
+        <%= f.date_select :end_date, prompt: "--", use_month_numbers: true, selected:Time.now.since(7.days), start_year: Time.now.year, end_year: Time.now.year + 2 %>
       </div>
 
       <div class="field">
         <%= f.label :adimg, class:"button_area_blue" %><br />
         <%= f.file_field :adimg, accept: "image/jpg, image/jpeg, image/png, image/gif" %>
+        <div class="ad_form_preview"></div>
       </div>
 
       <div class="center_buttons">
@@ -50,3 +51,4 @@
     <% end %>
   </div>
 </section>
+<%= javascript_include_tag "form_img_preview" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,6 +1,5 @@
 <section>
     <div class="wrap">
-
 <h2>サインアップ</h2>
 <div class="center_buttons p_item">
   <%= link_to "#{OmniAuth::Utils.camelize('Google')}でサインアップ", omniauth_authorize_path(resource_name, 'google_oauth2'), class:"button_area button_side p_item" %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,5 +13,5 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
 
-Rails.application.config.assets.precompile += %w( displays.js cropper_main.js lib/**/*.js )
+Rails.application.config.assets.precompile += %w( displays.js cropper_main.js form_img_preview.js lib/**/*.js )
 Rails.application.config.assets.precompile += %w( displays.css lib/**/*.css )


### PR DESCRIPTION
## Issue
close #172 


## 実装内容
広告登録時に画像をアップロードするとプレビューが表示される。
おまけで掲載開始日の初期値を今日、終了日の初期値を7日後に設定


## 未実装
画像の圧縮。広告なのでそもそもあまり行う必要性も低い。
フロントで容量制限はかけてもいいかもしれない。