### PR TITLE
Change password form to separate

### DIFF
--- a/app/controllers/passes_controller.rb
+++ b/app/controllers/passes_controller.rb
@@ -1,0 +1,33 @@
+class PassesController < ApplicationController
+  def edit
+    @user = User.new
+  end
+
+  def update
+    @user = current_user
+
+    if params[:user][:current_password].present?
+      if @user.valid_password?(params[:user][:current_password])
+        @user.assign_attributes(password_params)
+        if @user.save
+          flash[:success] = "パスワードを変更しました"
+          redirect_to user_path(@user.id)
+        else
+          render :edit
+        end
+      else
+        @user.errors.add(:current_password, :wrong)
+        render :edit
+      end
+    else
+      @user.errors.add(:current_password, :blank)
+      render :edit
+    end
+  end
+
+  private
+    # Params
+    def password_params
+      params.require(:user).permit(:password, :password_confirmation)
+    end
+end

--- a/app/controllers/passes_controller.rb
+++ b/app/controllers/passes_controller.rb
@@ -10,8 +10,9 @@ class PassesController < ApplicationController
       if @user.valid_password?(params[:user][:current_password])
         @user.assign_attributes(password_params)
         if @user.save
+          sign_in(:user, @user, bypass: true)
           flash[:success] = "パスワードを変更しました"
-          redirect_to user_path(@user.id)
+          redirect_to root_path
         else
           render :edit
         end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,7 +15,7 @@ class UsersController < ApplicationController
     if @user.destroy
       flash[:success] = "#{user_name}: 退会処理が完了しました"
     else
-      flash[:success] = "#{user_name}: 退会処理に失敗しました"
+      flash[:danger] = "#{user_name}: 退会処理に失敗しました"
     end
 
     redirect_to root_path

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,9 @@ class User < ApplicationRecord
          :omniauthable, omniauth_providers: %i[google_oauth2 twitter facebook]
 
   # Attribute
+  attr_accessor :current_password
   attr_accessor :profimg_temp
+
   enum  gender:  { man: 0, woman: 1, others: 2 }
   enum  personality: {
     noanswer: 0,
@@ -25,6 +27,7 @@ class User < ApplicationRecord
   # Validation
   validates :comment, length:{maximum: 40}
   validates :name, presence:true, length:{maximum: 16}
+  validates :password, presence: { if: :current_password }
 
   # CheckinRecord -> Shop
   has_many :checkin_record, dependent: :delete_all

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -15,22 +15,6 @@
         <%= f.text_field :name, autocomplete: "name" %>
       </div>
 
-      <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-        <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-      <% end %>
-
-      <div class="field">
-        <%= f.label :password %>変更<em>(<%= @minimum_password_length %>文字以上)</em><br />
-        <%= f.password_field :password, autocomplete: "new-password" %>
-        <% if @minimum_password_length %>
-        <% end %>
-      </div>
-
-      <div class="field">
-        <%= f.label :password_confirmation %><br />
-        <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-      </div>
-
       <div class="field">
         <%= f.label :gender %><i>(非公開)</i><br />
         <%= f.select :gender, User.genders.keys.map {|k| [I18n.t("enums.user.gender.#{k}"), k]} %>
@@ -39,7 +23,6 @@
       <div class="field">
         <%= f.label :personality %><a href="https://www.16personalities.com/ja" target="_blank"
         class="blue_text blue_underline label_supplement"><i>16Personalites診断を受けたことがない人はこちら</i></a>*外部サイトに飛びます<br>
-        <!-- <%= f.select :personality, User.personalities.keys.map {|k| [I18n.t("enums.user.personality.#{k}"), k]} %> -->
         <%= f.select :personality, grouped_options_for_select(Constants::PERSONALITY_SELECT_OPTIONS, @user.personality) %>
       </div>
 

--- a/app/views/passes/edit.html.erb
+++ b/app/views/passes/edit.html.erb
@@ -1,0 +1,30 @@
+<section>
+  <div class="wrap">
+    <h2>パスワード変更</h2>
+
+    <%= form_for @user, url: user_pass_path, html: { method: :put } do |f| %>
+      <%= render "devise/shared/error_messages", resource: @user %>
+
+      <div class="field">
+        <%= f.label :current_password %><br />
+        <%= f.password_field :current_password, autocomplete: "current-password" %>
+      </div>
+
+      <div class="field">
+        新しい<%= f.label :password %><em>(<%= User.password_length.min %>文字以上)</em><br />
+        <%= f.password_field :password, autocomplete: "new-password" %>
+      </div>
+
+      <div class="field">
+        新しい<%= f.label :password_confirmation %><br />
+        <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+      </div>
+
+      <div class="center_buttons">
+        <%= f.submit "パスワードを変更する", class:"button_area" %>
+      </div>
+    <% end %>
+  </div>
+
+  <%= render "devise/shared/assets" %>
+</section>

--- a/app/views/passes/edit.html.erb
+++ b/app/views/passes/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="wrap">
     <h2>パスワード変更</h2>
 
-    <%= form_for @user, url: user_pass_path, html: { method: :put } do |f| %>
+    <%= form_for @user, url: pass_path, html: { method: :put } do |f| %>
       <%= render "devise/shared/error_messages", resource: @user %>
 
       <div class="field">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -17,7 +17,7 @@
       <% if user_signed_in? and @user.id == current_user.id %>
         <div class="center_buttons">
           <%= link_to "プロフィール編集", edit_user_registration_path, class:"button_area prof_edit_button button_side" %>
-          <%= link_to "パスワード変更", edit_user_pass_path(current_user.id), class:"button_area prof_edit_button button_side" %>
+          <%= link_to "パスワード変更", edit_pass_path(current_user.id), class:"button_area prof_edit_button button_side" %>
         </div>
       <% end %>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -16,7 +16,8 @@
 
       <% if user_signed_in? and @user.id == current_user.id %>
         <div class="center_buttons">
-          <%= link_to "プロフィール編集", edit_user_registration_path, class:"button_area prof_edit_button" %>
+          <%= link_to "プロフィール編集", edit_user_registration_path, class:"button_area prof_edit_button button_side" %>
+          <%= link_to "パスワード変更", edit_user_pass_path(current_user.id), class:"button_area prof_edit_button button_side" %>
         </div>
       <% end %>
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,15 +1,17 @@
 ja:
   date:
     formats:
-      default: "%Y/%m/%d"
-      short: "%m/%d"
-      long: "%Y年%m月%d日(%a)"
+      default: '%Y/%m/%d'
+      short: '%m/%d'
+      long: '%Y年%m月%d日(%a)'
 
     day_names: [日曜日, 月曜日, 火曜日, 水曜日, 木曜日, 金曜日, 土曜日]
     abbr_day_names: [日, 月, 火, 水, 木, 金, 土]
 
-    month_names: [~, 1月, 2月, 3月, 4月, 5月, 6月, 7月, 8月, 9月, 10月, 11月, 12月]
-    abbr_month_names: [~, 1月, 2月, 3月, 4月, 5月, 6月, 7月, 8月, 9月, 10月, 11月, 12月]
+    month_names:
+      [~, 1月, 2月, 3月, 4月, 5月, 6月, 7月, 8月, 9月, 10月, 11月, 12月]
+    abbr_month_names:
+      [~, 1月, 2月, 3月, 4月, 5月, 6月, 7月, 8月, 9月, 10月, 11月, 12月]
 
     order:
       - :year
@@ -18,11 +20,11 @@ ja:
 
   time:
     formats:
-      default: "%Y/%m/%d %H:%M:%S"
-      short: "%y/%m/%d %H:%M"
-      long: "%Y年%m月%d日(%a) %H時%M分%S秒 %Z"
-    am: "午前"
-    pm: "午後"
+      default: '%Y/%m/%d %H:%M:%S'
+      short: '%y/%m/%d %H:%M'
+      long: '%Y年%m月%d日(%a) %H時%M分%S秒 %Z'
+    am: '午前'
+    pm: '午後'
 
   activerecord:
     models:
@@ -44,6 +46,7 @@ ja:
         name: 名前
         email: メールアドレス
         password: パスワード
+        current_password: 現在のパスワード
         remember_me: サインインを保存
         password_confirmation: パスワード確認
         interest_tag: タグ
@@ -76,6 +79,9 @@ ja:
         blank: が空欄です
       password_confirmation:
         confirmation: パスワード確認が一致していません
+      current_password:
+        wrong: が正しくありません
+        blank: が空欄です
       email:
         blank: が空欄です
         taken: が既に登録されています

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,9 @@ Rails.application.routes.draw do
   # User
   resources :users, only: [:show, :destroy] do
     get "image", to: "users#show_image"
+
+    # User Password
+    resource :pass, only: [:edit, :update]
   end
   get "user/destroy_confirmation", to: "users#destroy_confirmation"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,11 +26,11 @@ Rails.application.routes.draw do
   # User
   resources :users, only: [:show, :destroy] do
     get "image", to: "users#show_image"
-
-    # User Password
-    resource :pass, only: [:edit, :update]
   end
   get "user/destroy_confirmation", to: "users#destroy_confirmation"
+
+  # User Password
+  resource :pass, only: [:edit, :update]
 
   # Advertisement Image
   resources :advertisements, only: [:index, :create] do


### PR DESCRIPTION
## Issue

closes #163 

## 実装内容

- プロフィール編集画面とパスワード変更画面を分離

### プロフィール画面

![20-05-12_05-07-56_00](https://user-images.githubusercontent.com/6837211/81606778-99dbe700-940e-11ea-93ac-88f46bd50d11.png)

### パスワード変更画面

![20-05-12_05-08-07_00](https://user-images.githubusercontent.com/6837211/81606810-a7916c80-940e-11ea-8433-3641580f4a72.png)


## 確認方法

- ログイン後プロフィール画面からプロフィール編集画面/パスワード変更画面を確認
- パスワード変更を行う