### PR TITLE
Change lang of confirmation modal to ja

### DIFF
--- a/app/views/users/destroy_confirmation.html.erb
+++ b/app/views/users/destroy_confirmation.html.erb
@@ -4,7 +4,11 @@
 
     <p class="p_item">本当に退会しますか？</p>
     <div class="center_buttons">
-      <%= link_to "退会", user_path(current_user.id), method: "delete", class:"button_area_blue p_item", data: {confirm: '本当に実行しますか？'} %>
+      <%= link_to "退会", user_path(current_user.id), method: "delete", class:"button_area_blue p_item", data: {
+        confirm: "本当に実行しますか？",
+        cancel: "キャンセル",
+        commit: "退会",
+      }, title: "退会確認" %>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Issue

closes #184 

## 実装内容

- 退会時の確認モーダルの言語を日本語に変更

![20-05-15_02-41-25_00](https://user-images.githubusercontent.com/6837211/81967317-b4ec6800-9655-11ea-81e9-0e2ff9da6f67.png)

## 確認方法

- `/user/destroy_confirmation` から退会ボタンを押す