### PR TITLE
Update sns auth

### DIFF
--- a/app/controllers/passes_controller.rb
+++ b/app/controllers/passes_controller.rb
@@ -1,4 +1,7 @@
 class PassesController < ApplicationController
+  # Authentication
+  before_action :valid_password
+
   # New
   def new
     @user = User.new
@@ -48,6 +51,11 @@ class PassesController < ApplicationController
   end
 
   private
+    # Valid Password?
+    def valid_password
+      authorize Pass
+    end
+
     # Params
     def password_params
       params.require(:user).permit(:password, :password_confirmation)

--- a/app/controllers/passes_controller.rb
+++ b/app/controllers/passes_controller.rb
@@ -1,8 +1,29 @@
 class PassesController < ApplicationController
+  # New
+  def new
+    @user = User.new
+  end
+
+  # Create
+  def create
+    @user = current_user
+
+    @user.assign_attributes(password_params)
+    if @user.save
+      sign_in(:user, @user, bypass: true)
+      flash[:success] = "パスワードを登録しました"
+      redirect_to root_path
+    else
+      render :new
+    end
+  end
+
+  # Edit
   def edit
     @user = User.new
   end
 
+  # Update
   def update
     @user = current_user
 

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -3,6 +3,6 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
 
     def after_confirmation_path_for(resource_name, resource)
       sign_in(:user, resource)
-      root_path
+      edit_user_registration_path
     end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -22,7 +22,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     if info[:new]
       sign_in(:user, info[:user])
       flash[:success] = "アカウントを登録しました。"
-      redirect_to edit_user_registration_path(info[:user].id)
+      redirect_to edit_user_registration_path
     else
       sign_in_and_redirect info[:user], event: :authentication
       set_flash_message(:notice, :success, kind: "#{provider}".capitalize) if is_navigational_format?

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -21,6 +21,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     if info[:new]
       sign_in(:user, info[:user])
+      flash[:success] = "アカウントを登録しました。"
       redirect_to edit_user_registration_path(info[:user].id)
     else
       sign_in_and_redirect info[:user], event: :authentication

--- a/app/models/concerns/sns_auth_module.rb
+++ b/app/models/concerns/sns_auth_module.rb
@@ -10,7 +10,7 @@ module SnsAuthModule
       if sns.persisted?
         user = User.find_or_initialize_by(id: sns.user_id)
       else
-        user = User.find_or_initialize_by(email: auth.info.email)
+        user = User.new
       end
 
       if user.new_record?
@@ -20,14 +20,14 @@ module SnsAuthModule
         user.skip_confirmation!
 
         user.update_attributes({
-          name: auth.info.name,
+          name: auth.info.name[0..23],
           email: auth.info.email,
-          password: Devise.friendly_token[0,20],
           profimg: get_sns_image(auth.info.image, auth.provider),
+          create_by_sns: true,
         })
-      end
+       end
 
-      if sns.new_record?
+       if sns.new_record?
         sns.update_attributes({ user_id: user.id })
       end
 

--- a/app/models/pass.rb
+++ b/app/models/pass.rb
@@ -1,0 +1,2 @@
+class Pass < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,8 +59,10 @@ class User < ApplicationRecord
   # SNS Credentials
   has_many :sns_credentials, dependent: :destroy
 
-  # 
-
+  # Has Password?
+  def has_password?
+    return encrypted_password.present?
+  end
 
   # Review
   def review(other_user, rate, comment: "")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,7 @@ class User < ApplicationRecord
   # Attribute
   attr_accessor :current_password
   attr_accessor :profimg_temp
+  attr_accessor :create_by_sns
 
   enum  gender:  { man: 0, woman: 1, others: 2 }
   enum  personality: {
@@ -57,6 +58,9 @@ class User < ApplicationRecord
 
   # SNS Credentials
   has_many :sns_credentials, dependent: :destroy
+
+  # 
+
 
   # Review
   def review(other_user, rate, comment: "")
@@ -122,4 +126,8 @@ class User < ApplicationRecord
       checkin_record.where(shop_id: shop_id, created_at: Date.today.all_day).present?
     end
 
+    # Require Password?
+    def password_required?
+      super && !create_by_sns
+    end
 end

--- a/app/policies/pass_policy.rb
+++ b/app/policies/pass_policy.rb
@@ -1,0 +1,17 @@
+class PassPolicy < ApplicationPolicy
+  def new?
+    !user.has_password?
+  end
+
+  def create?
+    !user.has_password?
+  end
+
+  def edit?
+    user.has_password?
+  end
+
+  def update?
+    user.has_password?
+  end
+end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,5 +1,13 @@
 <section>
   <div class="wrap">
+    <% flash.each do |key, value| %>
+      <div class="alert_area">
+        <p class="alert alert-<%= key %>">
+          <%= value.html_safe %>
+        </p>
+      </div>
+    <% end %>
+
     <h2>プロフィール編集</h2>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -12,13 +12,13 @@
       <%= render "devise/shared/error_messages", resource: resource %>
 
       <div class="field">
-        <%= f.label :email %><i>(非公開)</i><br />
-        <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+        <%= f.label :name %><i>(16文字以内)</i><br />
+        <%= f.text_field :name, autocomplete: "name", autofocus: true %>
       </div>
 
       <div class="field">
-        <%= f.label :name %><i>(16文字以内)</i><br />
-        <%= f.text_field :name, autocomplete: "name" %>
+        <%= f.label :email %><i>(非公開)</i><br />
+        <%= f.email_field :email, autocomplete: "email" %>
       </div>
 
       <div class="field">
@@ -32,66 +32,6 @@
       <div class="field">
         <%= f.label :password_confirmation %><br />
         <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-      </div>
-
-      <div class="field">
-        <%= f.label :gender %><i>(非公開)</i><br />
-        <%= f.select :gender, User.genders.keys.map {|k| [I18n.t("enums.user.gender.#{k}"), k]} %>
-      </div>
-
-      <div class="field">
-        <%= f.label :birthday %><i>(非公開)</i><br />
-        <%= f.date_select :birthday, prompt: "--", use_month_numbers: true, start_year: Time.now.year, end_year:1900 %>
-      </div>
-
-      <div class="field">
-        <%= f.label :personality %><a href="https://www.16personalities.com/ja" target="_blank" class="blue_text blue_underline label_supplement"><i>16Personalites診断を受けたことがない人はこちら</i></a>*外部サイトに飛びます<br>
-        <!-- <%= f.select :personality, User.personalities.keys.map {|k| [I18n.t("enums.user.personality.#{k}"), k]} %> -->
-        <%= select_tag "user_personality", grouped_options_for_select(Constants::PERSONALITY_SELECT_OPTIONS), name:"user[personality]" %>
-      </div>
-
-      <div class="field">
-        <%= f.label :color_id %><br />
-        <%= f.select :color_id, Color.all.map {|k| [I18n.t("enums.user.color.#{k.name}"), k.id]} %>
-      </div>
-
-      <div class="field">
-        <%= f.label :shop_id %><br />
-        <%= f.select :shop_id, Shop.all.map {|k| [k.name, k.id]} %>
-      </div>
-
-      <div class="field">
-        <p>興味あるタグを選択してください(複数選択可)</p>
-        <% Category.all.each do |category| %>
-          <div class="category-container">
-            <span class="category"><%= category.name %></span><br>
-            <%= f.collection_check_boxes :tag_ids, Tag.where(category_id: category.id), :id, :name do |t| %>
-              <%= t.check_box + t.label{t.text} %>
-            <% end %>
-          </div>
-        <% end %>
-      </div>
-
-      <div class="field">
-        <%= f.label :organization %><br />
-        <%= f.text_field :organization, autocomplete: "organization" %>
-      </div>
-
-      <div class="field">
-        <%= f.label :comment %><i>(40文字以内)</i><br />
-        <%= f.text_area :comment %>
-      </div>
-
-      <div class="field">
-        <%= f.label :profimg, class:"button_area_blue" %><br />
-        <%= f.file_field :profimg, accept: "image/jpg, image/jpeg, image/png, image/gif" %>
-        <%= f.hidden_field :profimg_temp, id:"user_profimg_temp" %>
-      </div>
-
-      <div class="container">
-        <div class="img-container">
-          <%= image_tag '/assets/noavatar.png', id:"image" %>
-        </div>
       </div>
 
       <p>サインアップ前に下記の利用規約をお読みください。サインアップおよび本サービス利用にて、下記規約に同意したものとします。</p>

--- a/app/views/passes/new.html.erb
+++ b/app/views/passes/new.html.erb
@@ -1,0 +1,25 @@
+<section>
+  <div class="wrap">
+    <h2>パスワード登録</h2>
+
+    <%= form_for @user, url: pass_path, html: { method: :post } do |f| %>
+      <%= render "devise/shared/error_messages", resource: @user %>
+
+      <div class="field">
+        新しい<%= f.label :password %><em>(<%= User.password_length.min %>文字以上)</em><br />
+        <%= f.password_field :password, autocomplete: "new-password" %>
+      </div>
+
+      <div class="field">
+        新しい<%= f.label :password_confirmation %><br />
+        <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+      </div>
+
+      <div class="center_buttons">
+        <%= f.submit "パスワードを登録する", class:"button_area" %>
+      </div>
+    <% end %>
+  </div>
+
+  <%= render "devise/shared/assets" %>
+</section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -17,7 +17,11 @@
       <% if user_signed_in? and @user.id == current_user.id %>
         <div class="center_buttons">
           <%= link_to "プロフィール編集", edit_user_registration_path, class:"button_area prof_edit_button button_side" %>
-          <%= link_to "パスワード変更", edit_pass_path(current_user.id), class:"button_area prof_edit_button button_side" %>
+          <% if @user.has_password? %>
+            <%= link_to "パスワード変更", edit_pass_path, class:"button_area prof_edit_button button_side" %>
+          <% else %>
+            <%= link_to "パスワード登録", new_pass_path, class:"button_area prof_edit_button button_side" %>
+          <% end %>
         </div>
       <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
   get "user/destroy_confirmation", to: "users#destroy_confirmation"
 
   # User Password
-  resource :pass, only: [:edit, :update]
+  resource :pass, only: [:new, :create, :edit, :update]
 
   # Advertisement Image
   resources :advertisements, only: [:index, :create] do

--- a/db/migrate/20200514194212_change_column_to_user.rb
+++ b/db/migrate/20200514194212_change_column_to_user.rb
@@ -1,0 +1,9 @@
+class ChangeColumnToUser < ActiveRecord::Migration[5.2]
+  def up
+    change_column :users, :encrypted_password, :string, null: true
+  end
+
+  def down
+    change_column :users, :encrypted_password, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_09_081435) do
+ActiveRecord::Schema.define(version: 2020_05_14_194212) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -124,7 +124,7 @@ ActiveRecord::Schema.define(version: 2020_05_09_081435) do
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", null: false
-    t.string "encrypted_password", null: false
+    t.string "encrypted_password"
     t.string "organization"
     t.text "comment"
     t.string "reset_password_token"


### PR DESCRIPTION
## Issue

closes #183 

## 実装内容

- SNSでアカウント作成時のパスワードの扱いを変更
  + 作成時にランダムパスワードを設定しないように変更
  + プロフィールページにパスワード未設定の場合のための登録ページを作成

## 必要手順

```
rails db:migrate
```

## 確認方法

- SNSでアカウント作成 → プロフィールページでパスワード登録
- 通常通りアカウント作成 → プロフィールページでパスワード変更を確認

## 未実装

- SNSに紐付けられたメールアドレスに対しての認証