### PR TITLE
Apple WebAppモードをオン

### DIFF
--- a/app/views/layouts/display.html.erb
+++ b/app/views/layouts/display.html.erb
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>K-Display</title>
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>


### PR DESCRIPTION
K-Display画面のみ

## Issue
iOS系ブラウザでK-Displayを開くて検索バーが邪魔


## 確認方法
K-Displayのページをホーム画面に追加→ホームから起動

