### PR TITLE
Remove facebook authentication

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,7 +5,7 @@
     <div class="center_buttons p_item">
       <%= link_to "#{OmniAuth::Utils.camelize('Google')}でサインアップ", omniauth_authorize_path(resource_name, 'google_oauth2'), class:"button_area button_side p_item" %>
       <%= link_to "#{OmniAuth::Utils.camelize('Twitter')}でサインアップ", omniauth_authorize_path(resource_name, 'twitter'), class:"button_area button_side p_item" %>
-      <%= link_to "#{OmniAuth::Utils.camelize('Facebook')}でサインアップ", omniauth_authorize_path(resource_name, 'facebook'), class:"button_area button_side p_item" %>
+      <%# <%= link_to "#{OmniAuth::Utils.camelize('Facebook')}でサインアップ", omniauth_authorize_path(resource_name, 'facebook'), class:"button_area button_side p_item" %>
     </div>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -3,7 +3,7 @@
     <div class="smltopmargin">
       <%= link_to "#{OmniAuth::Utils.camelize('Google')}でサインイン", omniauth_authorize_path(resource_name, 'google_oauth2'), class:"button_area_blue button_side p_item" %>
       <%= link_to "#{OmniAuth::Utils.camelize('Twitter')}でサインイン", omniauth_authorize_path(resource_name, 'twitter'), class:"button_area_blue button_side p_item" %>
-      <%= link_to "#{OmniAuth::Utils.camelize('Facebook')}でサインイン", omniauth_authorize_path(resource_name, 'facebook'), class:"button_area_blue button_side p_item" %>
+      <%# <%= link_to "#{OmniAuth::Utils.camelize('Facebook')}でサインイン", omniauth_authorize_path(resource_name, 'facebook'), class:"button_area_blue button_side p_item" %>
     </div>
   <% end %>
 

--- a/app/views/lp/_lp_v1.html.erb
+++ b/app/views/lp/_lp_v1.html.erb
@@ -2,7 +2,7 @@
   <div class="wrap">
     <h2>Katharsis Digital Hubへようこそ</h2>
     <p class="p_item">語りバー「Katharsis」や連盟店舗に集う人々や企業をデジタルで繋げるシステムです。</p>
-    <p>メール認証のほかに、GoogleやTwitter、Facebookアカウントを認証することによってもアカウントを作成頂くことが可能です。</p>
+    <p>メール認証のほかに、GoogleやTwitterアカウントを認証することによってもアカウントを作成頂くことが可能です。</p>
   </div>
 </section>
 


### PR DESCRIPTION
## Issue

closes #205 

## 実装内容

- サインイン/アップページのFacebookのリンクをコメントアウト
- ランディングページの文章からFacebookの記述を削除

## 確認方法

- ランディングページ・サインイン/アップページを確認

![20-05-30_17-33-52_00](https://user-images.githubusercontent.com/6837211/83323791-03c40f80-a29c-11ea-9710-3015f66c875b.png)

![20-05-30_17-34-17_00](https://user-images.githubusercontent.com/6837211/83323794-09215a00-a29c-11ea-85fc-aae5cfe427b2.png)

![20-05-30_17-34-27_00](https://user-images.githubusercontent.com/6837211/83323797-0b83b400-a29c-11ea-916a-9b0836e1f6f8.png)
