### PR TITLE
Fix to be able to update email without confirmation on admin page

### DIFF
--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -21,6 +21,8 @@ ActiveAdmin.register User do
         params[:user][:profimg] = permitted_params[:user][:profimg].read
       end
 
+      @user.skip_reconfirmation!
+
       if permitted_params[:user][:password].blank?
         @user.update_without_password(permitted_params[:user])
       else


### PR DESCRIPTION
## Issue

closes #211 

## 実装内容

- 管理画面でEmail更新時にメール認証をスキップするよう変更