### PR TITLE
Hotfix/fix register user notimg

### DIFF
--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -6,8 +6,11 @@ ActiveAdmin.register User do
   controller do
     def create
       if permitted_params[:user][:profimg]
-        params[:user][:profimg] = permitted_params[:user][:profimg].read
+        file = permitted_params[:user][:profimg]
+      else
+        file = File.open("./app/assets/images/noavatar.png", "r")
       end
+      params[:user][:profimg] = file.read
 
       params[:user][:confirmed_at] = Time.now
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -2,8 +2,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def create
     if params[:user][:profimg_temp]
       file = trans_file(params[:user][:profimg_temp])
-      params[:user][:profimg] = file.read
+    else
+      file = File.open("./app/assets/images/noavatar.png", "r")
     end
+    params[:user][:profimg] = file.read
 
     super
 

--- a/app/views/app/index.html.erb
+++ b/app/views/app/index.html.erb
@@ -40,18 +40,10 @@
                 <%= link_to user_path(user.id) do %>
                   <div class="list_profimg_body">
                     <div class="list_mainimgframe">
-                      <% if user.profimg %>
-                        <% if user.id == current_user.id %>
-                          <%= image_tag user_image_path(current_user.id), class: "border_img" %>
-                        <% else %>
-                          <%= image_tag user_image_path(user.id) %>
-                        <% end %>
+                      <% if user.id == current_user.id %>
+                        <%= image_tag user_image_path(current_user.id), class: "border_img" %>
                       <% else %>
-                        <% if user.id == current_user.id %>
-                          <%= image_tag '/assets/noavatar.png', class: "border_img" %>
-                        <% else %>
-                          <%= image_tag '/assets/noavatar.png' %>
-                        <% end %>
+                        <%= image_tag user_image_path(user.id) %>
                       <% end %>
                     </div>
                   </div>

--- a/app/views/layouts/_display_user.html.erb
+++ b/app/views/layouts/_display_user.html.erb
@@ -2,9 +2,7 @@
   <div class="wrap">
     <div class="post_profimg">
       <div class="mainimgframe">
-        <% if user.profimg %>
-          <%= image_tag user_image_path(user.id) %>
-        <% end %>
+        <%= image_tag user_image_path(user.id) %>
       </div>
     </div>
 
@@ -27,7 +25,9 @@
     <div class="clearfix"></div>
 
     <div class="prof_msg multiline-text-container">
-      <% if user.comment? %><p class="prof_msg_body multiline-text-3"><%= user.comment %></p><% end %>
+      <% if user.comment? %>
+        <p class="prof_msg_body multiline-text-3"><%= user.comment %></p>
+      <% end %>
     </div>
   </div>
 </section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,11 +8,7 @@
       <% if @user.has_role? "guest" %>
         <div class="show_profimg p_item">
           <div class="show_mainimgframe">
-            <% if @user.profimg %>
-              <%= image_tag user_image_path(@user.id)%>
-            <% else %>
-              <%= image_tag '/assets/noavatar.png' %>
-            <% end %>
+            <%= image_tag user_image_path(@user.id)%>
           </div>
         </div>
       <% end %>


### PR DESCRIPTION
## Issue

closes #218 

## 実装内容

- ユーザ登録時、プロフィール画像を未設定の場合にnoavatar.pngを設定するように修正
- 上記に伴い、プロフィール画像表示の際の条件分岐を削除

## 確認方法

- 画像を設定せずにアカウントを作成
  + 通常画面から
  + 管理画面から
- 各ページを確認
  + プロフィールページ
  + チェックイン後のトップページ
  + displayページ