### PR TITLE
Add receiving email

### DIFF
--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -1,17 +1,17 @@
 ActiveAdmin.register User do
   # Permit
-  permit_params :name, :email, :password, :organization, :comment, :point, :gender, :personality, :birthday, :profimg, :color_id, :shop_id, :confirmed_at, role_ids: [], tag_ids: []
+  permit_params :name, :email, :password, :organization, :comment, :point, :gender, :personality, :birthday, :profimg, :color_id, :shop_id, :confirmed_at, :receiving_email, role_ids: [], tag_ids: []
 
   collection_action :download_users, method: :get do
     csv_data = CSV.generate do |csv|
       csv << [
         "id", "name", "email", "organization", "comment", "point",
-        "gender", "personality", "birthday", "color_id", "shop_id"
+        "gender", "personality", "birthday", "color_id", "shop_id", "receiving_email"
       ]
       User.find_each(batch_size: 500) do |user|
         csv << [
           user.id, user.name, user.email, user.organization, user.comment, user.point,
-          user.gender, user.personality, user.birthday, user.color_id, user.shop_id
+          user.gender, user.personality, user.birthday, user.color_id, user.shop_id, user.receiving_email
         ]
       end
     end
@@ -83,6 +83,7 @@ ActiveAdmin.register User do
     column 'Checkin' do |user|
       user.check_in?
     end
+    column :receiving_email
     column :created_at
     column :updated_at
     actions
@@ -106,6 +107,7 @@ ActiveAdmin.register User do
       row 'Checkin' do |user|
         user.check_in?
       end
+      row :receiving_email
       row :created_at
       row :updated_at
     end
@@ -142,6 +144,7 @@ ActiveAdmin.register User do
       f.input :roles
       f.input :shop
       f.input :point
+      f.input :receiving_email
     end
     f.actions
   end

--- a/app/controllers/concerns/devise_manager.rb
+++ b/app/controllers/concerns/devise_manager.rb
@@ -5,7 +5,7 @@ module DeviseManager
     before_action :configure_permitted_parameters, if: :devise_controller?
 
     def configure_permitted_parameters
-      added_attrs = [ :name, :organization, :profile, :comment, :birthday, :gender, :personality, :color_id, :shop_id, :profimg, tag_ids: [] ]
+      added_attrs = [ :name, :organization, :profile, :comment, :birthday, :gender, :personality, :color_id, :shop_id, :profimg, :receiving_email, tag_ids: [] ]
       devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
       devise_parameter_sanitizer.permit :account_update, keys: added_attrs
     end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -88,6 +88,11 @@
         </div>
       </div>
 
+      <div class="field">
+        <%= f.check_box :receiving_email %>
+        <%= f.label :receiving_email, "メールを受信する" %>
+      </div>
+
       <div class="center_buttons">
         <%= link_to :back, class:"button_area_blue action_button_side" do%>
           <span class="material-icons">backspace</span>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -92,6 +92,8 @@
           <% end %>
 
           <p class="p_item"><span class="material-icons">card_giftcard</span><b>ポイント </b><%= @user.point %> pt</p>
+
+          <p class="p_item"><span class="material-icons">send</span><b>メールの受信設定 </b><%= @user.receiving_email ? "受信する" : "受信しない" %></p>
         <% end %>
       <% end %>
       <% if current_user.has_role? :staff and @user.check_in? and current_user.shop.id == @user.get_checkin_shop.id %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -58,6 +58,7 @@ ja:
         comment: ひとこと
         profimg: プロフィール画像
         shop_id: マイショップ
+        receiving_email: メール受信の可否
       contact:
         name: 名前
         email: メールアドレス

--- a/db/migrate/20200618220812_add_receiving_email_to_user.rb
+++ b/db/migrate/20200618220812_add_receiving_email_to_user.rb
@@ -1,0 +1,5 @@
+class AddReceivingEmailToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :receiving_email, :bool, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_05_071028) do
+ActiveRecord::Schema.define(version: 2020_06_18_220812) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -131,6 +131,7 @@ ActiveRecord::Schema.define(version: 2020_06_05_071028) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.boolean "receiving_email", default: true, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
## Issue

#234

## 実装内容

- Userモデルに `receiving_email` を追加
- Viewに反映

## 必要手順

- `db:migrate`

## 確認方法

- プロフィール画面・管理画面を確認及び変更

## 未実装

- 登録/解除のルーティング作成